### PR TITLE
Health checks for services

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -28,8 +28,11 @@ var runDown = func(ctx context.Context, cfg *config.Config, args []string) error
 	g, ctx := errgroup.WithContext(ctx)
 	for _, srv := range proj.Services {
 		srv := srv // otherwise it goes out of scope
-		fmt.Printf("Stopping %s...\n", srv.String())
 		g.Go(func() error {
+			if !srv.IsHealthy(proj.IPAddr(), proj.VDPath()) {
+				return nil
+			}
+			fmt.Printf("Stopping %s...\n", srv.String())
 			stdout := bytes.Buffer{}
 			stderr := bytes.Buffer{}
 			err := srv.Stop(

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -36,8 +36,11 @@ var runUp = func(ctx context.Context, cfg *config.Config, args []string) error {
 	g, ctx := errgroup.WithContext(ctx)
 	for _, srv := range proj.Services {
 		srv := srv // otherwise it goes out of scope
-		fmt.Printf("Starting %s...\n", srv.String())
 		g.Go(func() error {
+			if srv.IsHealthy(proj.IPAddr(), proj.VDPath()) {
+				return nil
+			}
+			fmt.Printf("Starting %s...\n", srv.String())
 			// Initialize
 			{
 				stdout := bytes.Buffer{}

--- a/internal/catalog/service/memcached.go
+++ b/internal/catalog/service/memcached.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/andremedeiros/loon/internal/executer"
 	"github.com/andremedeiros/loon/internal/process"
@@ -37,6 +39,11 @@ func (m *Memcached) Environ(ipaddr, vdpath string) []string {
 	return []string{
 		fmt.Sprintf("MEMCACHED_URL=%s:11211", ipaddr),
 	}
+}
+
+func (m *Memcached) IsHealthy(ipaddr, _ string) bool {
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:11211", ipaddr), 100*time.Millisecond)
+	return err == nil
 }
 
 func (m *Memcached) Start(exe executer.Executer, ipaddr, vdpath string, opts ...executer.Option) error {

--- a/internal/catalog/service/mysql.go
+++ b/internal/catalog/service/mysql.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/andremedeiros/loon/internal/executer"
 )
@@ -45,6 +47,11 @@ func (m *Mysql) Environ(ipaddr, vdpath string) []string {
 	return []string{
 		fmt.Sprintf("DATABASE_URL=%s:3306", ipaddr),
 	}
+}
+
+func (m *Mysql) IsHealthy(ipaddr, _ string) bool {
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:3306", ipaddr), 100*time.Millisecond)
+	return err == nil
 }
 
 func (m *Mysql) Start(exe executer.Executer, ipaddr, vdpath string, opts ...executer.Option) error {

--- a/internal/catalog/service/postgresql.go
+++ b/internal/catalog/service/postgresql.go
@@ -3,8 +3,10 @@ package service
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/andremedeiros/loon/internal/executer"
 )
@@ -48,6 +50,11 @@ func (p *Postgres) Environ(ipaddr, vdpath string) []string {
 	return []string{
 		fmt.Sprintf("DATABASE_URL=postgres://%s:5432", ipaddr),
 	}
+}
+
+func (p *Postgres) IsHealthy(ipaddr, _ string) bool {
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:5432", ipaddr), 100*time.Millisecond)
+	return err == nil
 }
 
 func (p *Postgres) Start(exe executer.Executer, ipaddr, vdpath string, opts ...executer.Option) error {

--- a/internal/catalog/service/redis.go
+++ b/internal/catalog/service/redis.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/andremedeiros/loon/internal/executer"
 	"github.com/andremedeiros/loon/internal/process"
@@ -36,6 +38,11 @@ func (r *Redis) Environ(ipaddr, vdpath string) []string {
 	return []string{
 		fmt.Sprintf("REDIS_URL=redis://%s:6379", ipaddr),
 	}
+}
+
+func (r *Redis) IsHealthy(ipaddr, _ string) bool {
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:6379", ipaddr), 100*time.Millisecond)
+	return err == nil
 }
 
 func (r *Redis) Start(exe executer.Executer, ipaddr, vdpath string, opts ...executer.Option) error {

--- a/internal/catalog/service/service.go
+++ b/internal/catalog/service/service.go
@@ -7,6 +7,7 @@ type Service interface {
 	Identifier() string
 	Environ(string, string) []string
 	Initialize(executer.Executer, string, string, ...executer.Option) error
+	IsHealthy(string, string) bool
 	Start(executer.Executer, string, string, ...executer.Option) error
 	Stop(executer.Executer, string, string, ...executer.Option) error
 }


### PR DESCRIPTION
These are very basic, and shouldn't even be called health checks really.
They're a quick way to check with good enough certainty that a service
is running.

Closes #10