### PR TITLE
Fix DATABASE_URL for MySQL

### DIFF
--- a/internal/task/mysql.go
+++ b/internal/task/mysql.go
@@ -97,7 +97,7 @@ func (ms *MysqlStart) Resolve(_ context.Context, p *project.Project) error {
 
 func (*MysqlStart) Environ(_ context.Context, p *project.Project) (Environ, BinPaths) {
 	if checkProjectHasDep(p, "mysql") {
-		return []string{fmt.Sprintf("DATABASE_URL=%s:3306", p.IP)}, nil
+		return []string{fmt.Sprintf("DATABASE_URL=mysql2://%s:3306", p.IP)}, nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
```
❯ loon exec env bin/rails db:drop
rails aborted!
URI::InvalidURIError: bad URI(is not URI?): 127.0.12.90:3306
/Users/jojo/code/radiophonic/.loon/data/gem/gems/activerecord-6.0.3.2/lib/active_record/connection_adapters/connection_specification.rb:40:in `initialize'
```